### PR TITLE
allow users to launch the container with a custom command

### DIFF
--- a/rootfs/app-entrypoint.sh
+++ b/rootfs/app-entrypoint.sh
@@ -42,32 +42,34 @@ log () {
   echo -e "\033[0;33m$(date "+%H:%M:%S")\033[0;37m ==> $1."
 }
 
-if ! app_present; then
-  log "Creating laravel application"
-  \cp -r /tmp/app/ /
-fi
+if [ "${1}" == "php" -a "$2" == "artisan" -a "$3" == "serve" ]; then
+  if ! app_present; then
+    log "Creating laravel application"
+    \cp -r /tmp/app/ /
+  fi
 
-if ! dependencies_up_to_date; then
-  log "Installing/Updating Laravel dependencies (composer)"
-  composer update
-  log "Dependencies updated"
-fi
+  if ! dependencies_up_to_date; then
+    log "Installing/Updating Laravel dependencies (composer)"
+    composer update
+    log "Dependencies updated"
+  fi
 
-wait_for_db
+  wait_for_db
 
-if ! fresh_container; then
-  echo "#########################################################################"
-  echo "                                                                         "
-  echo " App initialization skipped:                                             "
-  echo " Delete the file $INIT_SEM and restart the container to reinitialize     "
-  echo " You can alternatively run specific commands using docker-compose exec   "
-  echo " e.g docker-compose exec myapp php artisan make:console FooCommand       "
-  echo "                                                                         "
-  echo "#########################################################################"
-else
-  setup_db
-  log "Initialization finished"
-  touch $INIT_SEM
+  if ! fresh_container; then
+    echo "#########################################################################"
+    echo "                                                                         "
+    echo " App initialization skipped:                                             "
+    echo " Delete the file $INIT_SEM and restart the container to reinitialize     "
+    echo " You can alternatively run specific commands using docker-compose exec   "
+    echo " e.g docker-compose exec myapp php artisan make:console FooCommand       "
+    echo "                                                                         "
+    echo "#########################################################################"
+  else
+    setup_db
+    log "Initialization finished"
+    touch $INIT_SEM
+  fi
 fi
 
 exec /entrypoint.sh "$@"


### PR DESCRIPTION
The `app-entrypoint.sh` performs the container setup bits only if the
specified command is prefixed with `bundle exec`. In other cases the
specified command is launched without any container initializations.

f.e. `docker run -it --rm laravel bash` will start the `bash` command
inside the container.