### PR TITLE
Run myapp container in privileged mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,10 @@ Among other things, the above command creates a container service, named `myapp`
 
 After the artisan application server has been launched in the `myapp` service, visit http://localhost:3000 in your favorite web browser and you'll be greeted by the default Laravel welcome page.
 
+> **Note**
+>
+> If no application available at http://localhost:3000 and you're running Docker on Windows, you might need to uncomment `privileged` setting for `myapp` container. Later, re-launch the Laravel application development environment as stated before.
+
 In addition to the Laravel Development Container, the [docker-compose.yml](https://raw.githubusercontent.com/bitnami/bitnami-docker-laravel/master/docker-compose.yml) file also configures a MariaDB service to serve as the database backend of your Laravel application.
 
 ## Executing commands

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,4 +23,4 @@ services:
       - 3000:3000
     volumes:
       - ./:/app
-    privileged: true
+    # privileged: true # Privileged mode could be required to run this container under Windows

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,3 +23,4 @@ services:
       - 3000:3000
     volumes:
       - ./:/app
+    privileged: true


### PR DESCRIPTION
Windows may require myapp container to run in privileged mode to avoid Operation not permitted when preserving times (V. #102)

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Added property to run myapp container in privileged mode

**Benefits**

Frictionless starting container under Windows

**Possible drawbacks**

Unknown

**Applicable issues**

#102

**Additional information**

N/A
