### PR TITLE
Update entrypoint to stop it updating database config (Closes #129)

### DIFF
--- a/6/debian-10/rootfs/app-entrypoint.sh
+++ b/6/debian-10/rootfs/app-entrypoint.sh
@@ -68,7 +68,6 @@ wait_for_db() {
 #########################
 setup_db() {
   log "Configuring the database"
-  replace_in_file "/app/config/database.php" "utf8mb4" "utf8"
   php artisan migrate --force
 }
 

--- a/7/debian-10/rootfs/app-entrypoint.sh
+++ b/7/debian-10/rootfs/app-entrypoint.sh
@@ -68,7 +68,6 @@ wait_for_db() {
 #########################
 setup_db() {
   log "Configuring the database"
-  replace_in_file "/app/config/database.php" "utf8mb4" "utf8"
   php artisan migrate --force
 }
 


### PR DESCRIPTION
**Description of the change**

Update entrypoint to stop it updating database config as per discussion on #129 

**Benefits**

Docker image will no longer touch the working directory, and allow the user to define their own charset. 

**Possible drawbacks**

Backward Compatibility? It might be possible that a reliance on this change has been made unaware?

**Applicable issues**

#129 
