### PR TITLE
Update app-entrypoint.sh

### DIFF
--- a/8/debian-10/rootfs/app-entrypoint.sh
+++ b/8/debian-10/rootfs/app-entrypoint.sh
@@ -62,11 +62,11 @@ wait_for_db() {
     local db_address
     db_address=$(getent hosts "$db_host" | awk '{ print $1 }')
     local counter=0
-    log "Connecting to mariadb at $db_address"
+    log "Connecting to $db_host at $db_address:$db_port"
     while ! nc -z "$db_address" "$db_port" >/dev/null; do
         counter=$((counter + 1))
         if [ $counter == 30 ]; then
-            log "Error: Couldn't connect to mariadb."
+            log "Error: Couldn't connect to db_host."
             exit 1
         fi
         log "Trying to connect to mariadb at $db_address. Attempt $counter."

--- a/8/debian-10/rootfs/app-entrypoint.sh
+++ b/8/debian-10/rootfs/app-entrypoint.sh
@@ -62,7 +62,7 @@ wait_for_db() {
     local db_address
     db_address=$(getent hosts "$db_host" | awk '{ print $1 }')
     local counter=0
-    log "Connecting to $db_host at $db_address:$db_port"
+    log "Connecting to database at ${db_address}:${db_port}"
     while ! nc -z "$db_address" "$db_port" >/dev/null; do
         counter=$((counter + 1))
         if [ $counter == 30 ]; then

--- a/8/debian-10/rootfs/app-entrypoint.sh
+++ b/8/debian-10/rootfs/app-entrypoint.sh
@@ -66,7 +66,7 @@ wait_for_db() {
     while ! nc -z "$db_address" "$db_port" >/dev/null; do
         counter=$((counter + 1))
         if [ $counter == 30 ]; then
-            log "Error: Couldn't connect to db_host."
+            log "Error: Couldn't connect to the database"
             exit 1
         fi
         log "Trying to connect to mariadb at $db_address. Attempt $counter."


### PR DESCRIPTION
**Description of the change**

Some database references were hard-coded in the `app-entrypoint.sh` file.
They have been replaced by the corresponding variable.

Also, the port number has been added to the log output to help any missing configuration when using another DB engine than MariaDB.

**Benefits**

This change will prevent users (like me) to believe that they containerized laravel app is using MariaDB although the environment variables are set so that the DB engine to use is Postgresql.

**Possible drawbacks**

No drawbacks AFAIK.

**Applicable issues**

No issues AFAIK.

**Additional information**

I lost 30 minutes asking myself «why aren’t the varenvs use by the container 🤔» ... and then «why isn’t the right port number used 🤨» ... I may not be the sharpest tool in the shed 🤣 ...
(you asked for additional informations, not useful ones 😉)